### PR TITLE
Fixes gyp formula to work with system Python

### DIFF
--- a/gyp.rb
+++ b/gyp.rb
@@ -11,7 +11,8 @@ class Gyp < Formula
      # initialize the installation of this
      def install
              # use the brew python to install the tools needed
-	     system 'python', 'setup.py', 'install'
+	     system 'python', 'setup.py', 'install', "--prefix=#{prefix}", "--single-version-externally-managed", "--record=installed.txt"
+
 
              # install the gyp executable
              bin.install("gyp")


### PR DESCRIPTION
This avoids the following error noted at https://github.com/tessel/runtime#os-x:

> ==> Checking out http://gyp.googlecode.com/svn/trunk/
> ==> python setup.py install
> 
>   http://peak.telecommunity.com/EasyInstall.html
> 
> Please make the appropriate changes for your system and try again.

This is due to a simple permissions error — it's trying to install to the default (i.e. system-wide in this case) Python but can't write there. Fixing is relatively simple, just needs to be installed within Homebrew's prefix plus some other "older setup.py" workarounds as documented in https://github.com/Homebrew/homebrew/wiki/Homebrew-and-Python#if-the-software-provides-a-setuppy
