### PR TITLE
Switch from sha1 to sha256

### DIFF
--- a/gcc-arm.rb
+++ b/gcc-arm.rb
@@ -3,7 +3,7 @@ require "formula"
 class GccArm < Formula
   homepage "https://launchpad.net/gcc-arm-embedded"
   url "https://launchpad.net/gcc-arm-embedded/4.8/4.8-2014-q1-update/+download/gcc-arm-none-eabi-4_8-2014q1-20140314-mac.tar.bz2"
-  sha1 "b40c4127f641170f016b77ad423caf8dfd46faac"
+  sha256 "d8d037d56e37c513f13f3b8864265489dca9ffaca616f679d45dff6e500c47af"
 
   def install
     prefix.install Dir["*"]

--- a/qemu.rb
+++ b/qemu.rb
@@ -4,7 +4,7 @@ class Qemu < Formula
   homepage "http://www.qemu.org/"
   head "git://git.qemu-project.org/qemu.git"
   url "http://wiki.qemu-project.org/download/qemu-2.1.0.tar.bz2"
-  sha1 "b2829491e4c2f3d32f7bc2860c3a19fb31f5e989"
+  sha256 "397e23184f4bf613589a8fe0c6542461dc2afdf17ed337e97e6fd2f31e8f8802"
 
   bottle do
     sha1 "52345b6ec0fb3a9a4da93b3adc861e247a9d8702" => :mavericks


### PR DESCRIPTION
Prevents the following warning when using the latest version of Homebrew

> Warning: Calling Resource#sha1 is deprecated!
> Use Resource#sha256 instead.
> /usr/local/Library/Taps/tessel/homebrew-tools/gcc-arm.rb:6:in `<class:GccArm>'
> Please report this to the tessel/tools tap!