### PR TITLE
Update Gyp formula for latest Brew

### DIFF
--- a/gyp.rb
+++ b/gyp.rb
@@ -5,7 +5,7 @@ class Gyp < Formula
       url "https://chromium.googlesource.com/external/gyp", :using => :git
       version "1.0"
 
-      depends_on :python
+      depends_on "python@2"
 
      # initialize the installation of this
      def install


### PR DESCRIPTION
Fixes the following error:

```text
Error: Calling 'depends_on :python' is disabled!
Use 'depends_on "python@2"' instead.
/usr/local/Homebrew/Library/Taps/tessel/homebrew-tools/gyp.rb:8:in `<class:Gyp>'
Please report this to the tessel/tools tap!
Or, even better, submit a PR to fix it!
If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/tessel/homebrew-tools/issues
```